### PR TITLE
[issues-9] Removes $nth-child-separator in favor of $selector-separator

### DIFF
--- a/grid/_column-policy-private.scss
+++ b/grid/_column-policy-private.scss
@@ -101,10 +101,9 @@ $column-policy-internal-first-use: true !default;
     @if ($column-policy-flag-nth-child-hack-support) {
         @while ($item-count < $column-policy-flag-nth-child-hack-depth) {
             $column-selectors: $column-selectors + $selector-separator + _column-policy-nth-child-hack($item-count + $current, ".column");
-            $nth-child-separator: ",";
+            $selector-separator: ",";
             $item-count: $item-count + $total;
         }
-        $selector-separator: ",";
     }
 
     @return $column-selectors;


### PR DESCRIPTION
$nth-child-separator was not being used in the code. $selector-separator
is the perferred variable to use.
