### PR TITLE
[issues-26] Adds condition to generate overflow if calc is not supported

### DIFF
--- a/dist/_column-policy.scss
+++ b/dist/_column-policy.scss
@@ -150,8 +150,11 @@
     }
 
     & {
+        @if ($column-policy-flag-calc-support != true) {
+            overflow: hidden;
+        }
+
         @include clearfix;
-        overflow: hidden;
     }
 
     //


### PR DESCRIPTION
When using calc overflow is not nessessary since there is no over
flow with margins and padding.
